### PR TITLE
FoD API response inconsistent for user/token auth

### DIFF
--- a/fortify-util/rest-util/src/main/java/com/fortify/util/rest/RestConnection.java
+++ b/fortify-util/rest-util/src/main/java/com/fortify/util/rest/RestConnection.java
@@ -131,7 +131,7 @@ public class RestConnection implements IRestConnection {
 			Integer reasonCode = status.getStatusCode();
 			String reasonPhrase = getReasonPhrase(response);
 			String className = this.getClass().toString();
-			if (reasonCode.equals(401))
+			if (reasonCode.equals(401) || reasonCode.equals(400)) //FOD gives a 400 error for bad user credentials and a 401 for bad token/secret. Interim fix is to assume our auth request is well-formed and is simple bad creds.
 			{
 				if (className.contains("fod"))
 				{


### PR DESCRIPTION
Added 400 (bad request) as an assumption of bad user/password. API responds with 401 unauthorized for bad token/secret credentials.

I'll file a report with FoD.